### PR TITLE
Add functional settings modal with user preferences (Vibe Kanban)

### DIFF
--- a/campy/Views/Components/SettingsView.swift
+++ b/campy/Views/Components/SettingsView.swift
@@ -1,0 +1,170 @@
+//
+//  SettingsView.swift
+//  campy
+//
+//  Settings modal with app preferences
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("notificationsEnabled") private var notificationsEnabled = true
+    @AppStorage("soundEnabled") private var soundEnabled = true
+    @AppStorage("hapticsEnabled") private var hapticsEnabled = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Handle
+            SheetHandle()
+                .padding(.top, CampySpacing.md)
+
+            // Header
+            Text("Settings")
+                .font(CampyFonts.header())
+                .foregroundColor(CampyColors.textPrimary)
+                .padding(.top, CampySpacing.lg)
+
+            SheetDivider()
+                .padding(.horizontal, CampySpacing.lg)
+
+            // Settings list
+            ScrollView {
+                VStack(spacing: CampySpacing.sm) {
+                    // Preferences section
+                    SettingsSection(title: "Preferences") {
+                        SettingsToggleRow(
+                            icon: "bell.fill",
+                            title: "Notifications",
+                            isOn: $notificationsEnabled
+                        )
+
+                        SettingsToggleRow(
+                            icon: "speaker.wave.2.fill",
+                            title: "Sound Effects",
+                            isOn: $soundEnabled
+                        )
+
+                        SettingsToggleRow(
+                            icon: "iphone.radiowaves.left.and.right",
+                            title: "Haptic Feedback",
+                            isOn: $hapticsEnabled
+                        )
+                    }
+
+                    // About section
+                    SettingsSection(title: "About") {
+                        SettingsInfoRow(
+                            icon: "info.circle.fill",
+                            title: "Version",
+                            value: appVersion
+                        )
+                    }
+                }
+                .padding(.horizontal, CampySpacing.lg)
+            }
+
+            Spacer()
+        }
+        .background(CampyColors.sheetBackground)
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.hidden)
+    }
+
+    private var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        return "\(version) (\(build))"
+    }
+}
+
+// MARK: - Settings Section
+struct SettingsSection<Content: View>: View {
+    let title: String
+    let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CampySpacing.sm) {
+            Text(title)
+                .font(CampyFonts.caption())
+                .foregroundColor(CampyColors.textSecondary)
+                .padding(.leading, CampySpacing.sm)
+
+            VStack(spacing: 1) {
+                content
+            }
+            .background(CampyColors.cardBackground)
+            .cornerRadius(CampyRadius.large)
+        }
+        .padding(.bottom, CampySpacing.md)
+    }
+}
+
+// MARK: - Settings Toggle Row
+struct SettingsToggleRow: View {
+    let icon: String
+    let title: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack(spacing: CampySpacing.md) {
+            Image(systemName: icon)
+                .font(.system(size: 18))
+                .foregroundColor(CampyColors.accent)
+                .frame(width: 24)
+
+            Text(title)
+                .font(CampyFonts.body())
+                .foregroundColor(CampyColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $isOn)
+                .tint(CampyColors.accent)
+                .labelsHidden()
+        }
+        .padding(.horizontal, CampySpacing.md)
+        .padding(.vertical, CampySpacing.md)
+    }
+}
+
+// MARK: - Settings Info Row
+struct SettingsInfoRow: View {
+    let icon: String
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(spacing: CampySpacing.md) {
+            Image(systemName: icon)
+                .font(.system(size: 18))
+                .foregroundColor(CampyColors.accent)
+                .frame(width: 24)
+
+            Text(title)
+                .font(CampyFonts.body())
+                .foregroundColor(CampyColors.textPrimary)
+
+            Spacer()
+
+            Text(value)
+                .font(CampyFonts.body())
+                .foregroundColor(CampyColors.textSecondary)
+        }
+        .padding(.horizontal, CampySpacing.md)
+        .padding(.vertical, CampySpacing.md)
+    }
+}
+
+#Preview {
+    ZStack {
+        CampyColors.background.ignoresSafeArea()
+
+        SettingsView()
+    }
+}

--- a/campy/Views/Home/HomeView.swift
+++ b/campy/Views/Home/HomeView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HomeView: View {
     @Bindable var viewModel: HomeViewModel
     @Environment(WalletManager.self) private var walletManager
+    @State private var showSettings = false
 
     var body: some View {
         ZStack {
@@ -61,6 +62,9 @@ struct HomeView: View {
         .sheet(isPresented: $viewModel.showJoinSession) {
             JoinSessionSheet(viewModel: viewModel)
         }
+        .sheet(isPresented: $showSettings) {
+            SettingsView()
+        }
     }
 
     private var headerView: some View {
@@ -72,7 +76,7 @@ struct HomeView: View {
 
             // Settings button
             Button(action: {
-                // Settings action
+                showSettings = true
             }) {
                 Image(systemName: "gearshape.fill")
                     .font(.system(size: 22))

--- a/campy/Views/Wallet/WalletView.swift
+++ b/campy/Views/Wallet/WalletView.swift
@@ -12,6 +12,7 @@ struct WalletView: View {
     @Environment(StoreKitManager.self) private var storeKitManager
 
     @State private var viewModel = WalletViewModel()
+    @State private var showSettings = false
 
     var body: some View {
         ZStack {
@@ -52,13 +53,18 @@ struct WalletView: View {
         } message: {
             Text("Withdrawals will be available in a future update.")
         }
+        .sheet(isPresented: $showSettings) {
+            SettingsView()
+        }
     }
 
     private var headerView: some View {
         HStack {
             BalanceView(balance: walletManager.balance, style: .compact)
             Spacer()
-            Button(action: {}) {
+            Button(action: {
+                showSettings = true
+            }) {
                 Image(systemName: "gearshape.fill")
                     .font(.system(size: 22))
                     .foregroundColor(CampyColors.textSecondary)


### PR DESCRIPTION
## Summary

This PR implements a functional settings modal that is accessible from the gear icon in the top right corner of both the Home and Wallet screens.

## Changes Made

### New File: `SettingsView.swift`
- Created a new settings modal component with the following features:
  - **Notifications toggle** - Enable/disable push notifications
  - **Sound Effects toggle** - Enable/disable in-app sounds
  - **Haptic Feedback toggle** - Enable/disable haptic feedback
  - **App Version display** - Shows current version and build number
- All preferences are persisted using `@AppStorage` (UserDefaults)
- Follows the app's existing design patterns using `CampyColors`, `CampyFonts`, `CampySpacing`, and `CampyRadius` design tokens
- Includes reusable components: `SettingsSection`, `SettingsToggleRow`, and `SettingsInfoRow`

### Updated: `HomeView.swift`
- Added `showSettings` state variable
- Wired the settings button action to open the settings modal
- Added sheet presentation for `SettingsView`

### Updated: `WalletView.swift`
- Added `showSettings` state variable
- Wired the settings button action to open the settings modal
- Added sheet presentation for `SettingsView`

## Implementation Details

- The settings modal uses SwiftUI's `.sheet()` modifier with `.presentationDetents([.medium])` for a half-screen presentation
- Settings are organized into sections (Preferences, About) for better UX
- The modal follows the existing sheet patterns in the app, using `SheetHandle` and `SheetDivider` components
- Toggle switches use the app's accent color for visual consistency

---

This PR was written using [Vibe Kanban](https://vibekanban.com)