### PR TITLE
Increase coin mascot asset sizes for better visibility (Vibe Kanban)

### DIFF
--- a/campy/Views/Components/BalanceView.swift
+++ b/campy/Views/Components/BalanceView.swift
@@ -31,7 +31,7 @@ struct BalanceView: View {
                 .font(CampyFonts.body())
                 .foregroundColor(CampyColors.textPrimary)
 
-            coinIcon(size: 16)
+            coinIcon(size: 32)
         }
         .padding(.horizontal, CampySpacing.md)
         .padding(.vertical, CampySpacing.sm)
@@ -69,7 +69,7 @@ struct BalanceView: View {
 
 // MARK: - Coin Mascot View
 struct CoinMascotView: View {
-    var size: CGFloat = 80
+    var size: CGFloat = 120
 
     var body: some View {
         Image("coin-mascot")

--- a/campy/Views/Wallet/WalletView.swift
+++ b/campy/Views/Wallet/WalletView.swift
@@ -69,7 +69,7 @@ struct WalletView: View {
     private var balanceSection: some View {
         VStack(spacing: CampySpacing.md) {
             // Coin mascot
-            CoinMascotView(size: 80)
+            CoinMascotView(size: 120)
 
             // Balance display
             BalanceView(balance: walletManager.balance, style: .expanded)
@@ -200,7 +200,7 @@ struct CoinPackageCard: View {
         Button(action: action) {
             VStack(spacing: CampySpacing.sm) {
                 // Coin icon
-                CoinMascotView(size: 40)
+                CoinMascotView(size: 64)
 
                 // Coin amount
                 Text("\(package.coins)")


### PR DESCRIPTION
## Summary

Increases the coin mascot asset sizes throughout the app to improve visibility. The coin icon was previously too small to be easily seen by users.

## Changes Made

| Location | Previous Size | New Size |
|----------|---------------|----------|
| Compact balance view (header) | 16pt | 32pt |
| CoinMascotView default | 80pt | 120pt |
| Wallet balance section | 80pt | 120pt |
| Coin package cards | 40pt | 64pt |

## Files Modified

- `campy/Views/Components/BalanceView.swift` - Updated compact coin icon size and CoinMascotView default
- `campy/Views/Wallet/WalletView.swift` - Updated wallet balance section and coin package card sizes

## Why

The coin mascot asset was too small across the entire app, making it difficult for users to see. These size increases (roughly 1.5-2x larger) ensure the coin is prominently visible in all contexts where it appears.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)